### PR TITLE
Update gcc requirement.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ libc = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3"
-gcc = "0.3.10"
+gcc = "0.3.17"


### PR DESCRIPTION
This library expects `get_compiler()` to return a `Tool` rather than a tuple, which is correct starting in 0.3.17.
